### PR TITLE
fix the MOV instruction

### DIFF
--- a/src/cpu.hpp
+++ b/src/cpu.hpp
@@ -103,7 +103,7 @@ public:
 		Dest = (inst & 0x0000F000) >> (3*4);
 		switch (opcode){
 			case OP_R_MOV:
-				cpu_mov(S1, Dest);
+				cpu_mov(S2, Dest);
 				break;
 			case OP_R_ADD:
 				cpu_add(S1, S2, Dest);


### PR DESCRIPTION
the MOV instruction wasn't being decoded properly. When a MOV instruction is invoked, the source register should be decoded from S2, not from S1. This bug made MOV an effective NOP, which is now fixed.